### PR TITLE
README.md minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,31 @@
 Moga (ਮੋਗਾ)
 =========
 
-Moga (ਮੋਗਾ) is an informal, handwriting-style font. When we write, our hands can move at many different speeds. Even though Moga is a font—and not actual handwriting—text typed with it looks as if it has been written slowly, not in a  hurried manner. Think of it as closer to “love letters” on the handwriting-spectrum, rather than a grocery shopping list.
+Moga (ਮੋਗਾ) is an informal, handwriting-style font. 
+When we write, our hands can move at many different speeds. 
+Even though Moga is a font—and not actual handwriting—text typed with it looks as if it has been written slowly, not in a hurried manner. 
+Think of it as closer to “love letters” on the handwriting-spectrum, rather than a grocery shopping list.
 
-This slowness leads to Moga’s even and static-looking letterforms. Each letter in the font appears typographically-informed – they look very much like printed characters, not like the ones taught in elementary school penmanship classes. Moga Latin-script letters are not joining; each one lives in its own space, with the exception of a few ligatures.
+This slowness leads to Moga’s even and static-looking letterforms. 
+Each letter in the font appears typographically-informed – they look very much like printed characters, not like the ones taught in elementary school penmanship classes. 
+Moga Latin-script letters are not joining; each one lives in its own space, with the exception of a few ligatures.
 
-This font is currently available, libre and gratis, via GitHub.  It includes both Gurmukhi-script and Latin-script characters. This means that, in addition to Punjabi and English, Moga can be used for most of the Western European languages that are written with the Latin alphabet, including Albanian, Czech, Danish, Dutch, Estonian, Finnish, French, German, Hungarian, Icelandic, Italian, Latvian, Lithuanian, Norwegian, Polish, Portuguese, Romanian, Slovak, Spanish, Swedish, Turkish, and Welsh.
+This font is currently available, libre and gratis, via GitHub. 
+It includes both Gurmukhi-script and Latin-script characters. 
+This means that, in addition to Punjabi and English, Moga can be used for most of the Western European languages that are written with the Latin alphabet, including Albanian, Czech, Danish, Dutch, Estonian, Finnish, French, German, Hungarian, Icelandic, Italian, Latvian, Lithuanian, Norwegian, Polish, Portuguese, Romanian, Slovak, Spanish, Swedish, Turkish, and Welsh.
 
-The font includes one stylistic set, discretionary ligatures, and oldstyle figures available via the <onum> OpenType feature. Among other things, this stylistic set offers single-storey “a” and “g” glyphs.
+The font includes one stylistic set, discretionary ligatures, and oldstyle figures available via the “onum” OpenType feature. 
+Among other things, this stylistic set offers single-storey “a” and “g” glyphs.
 
-<h2>Files</h2>
-Several folders will be hosted here: <em>releases</em>, <em>sources</em>, and a <em>test</em> folder. The releases folder contains both PostScript-flavored OpenType fonts (.otf) and TrueType-flavored fonts (.ttf). The .ttf-files are auto-hinted with ttfautohint version 1.3. All of the font <em>releases</em> will be generated from <em>sources</em> that are files for the Glyphs 2 font editing application. The sources files folder will eventually also contain a UFO file exported from Glyphs, too. The <em>test</em> folder contains PDF files, and the .otf files used to set them.
+Files
+------
 
-All files are offered as-is, but support is available on request. Let me know if your like the font, or if you don’t!
+Several folders will be hosted here: _releases_, _sources_, and a _test_ folder. 
+The releases folder contains both PostScript-flavored OpenType fonts (.otf) and TrueType-flavored fonts (.ttf). 
+The .ttf-files are auto-hinted with ttfautohint version 1.3. 
+All of the font _releases_ will be generated from _sources_ that are files for the Glyphs 2 font editing application. 
+The sources files folder will eventually also contain a UFO file exported from Glyphs, too. 
+The _test_ folder contains PDF files, and the .otf files used to set them.
+
+All files are offered as-is, but support is available on request. 
+Let me know if your like the font, or if you don’t!


### PR DESCRIPTION
- replaced two spaces with one
- put each sentence on 1 line, which doesn't change formatted output but makes diffing easier
- replaced use of angle brackets as quote marks with real marks, as caused the text inside to be dropped
- replaced html markup with markdown
